### PR TITLE
Can't derive Apiv2Schema on struct using HashMap<Uuid, String>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ members = [
 
 [[test]]
 name = "test_app"
-required-features = ["actix"]
+required-features = ["actix", "uuid"]
 
 [[test]]
 name = "test_codegen"

--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -362,7 +362,7 @@ macro_rules! impl_schema_array {
 
 macro_rules! impl_schema_map {
     ($ty:ty) => {
-        impl<K: AsRef<str>, V: Apiv2Schema> Apiv2Schema for $ty {
+        impl<K: ToString, V: Apiv2Schema> Apiv2Schema for $ty {
             fn raw_schema() -> DefaultSchemaRaw {
                 let mut schema = DefaultSchemaRaw::default();
                 schema.data_type = Some(DataType::Object);


### PR DESCRIPTION
As provided in a test case
```
    #[derive(Serialize, Apiv2Schema)]
    struct Catalogue {
        pub folders: HashMap<Uuid, Vec<Image>>
    }
```

produces error:
```
   --> tests/test_app.rs:841:25
    |
841 |     #[derive(Serialize, Apiv2Schema)]
    |                         ^^^^^^^^^^^ function or associated item not found in `std::collections::HashMap<uuid::Uuid, std::vec::Vec<test_map_in_out::Image>>`
    |
    = note: the method `raw_schema` exists but the following trait bounds were not satisfied:
            `&std::collections::HashMap<uuid::Uuid, std::vec::Vec<test_map_in_out::Image>>: paperclip_core::v2::schema::TypedData`
            which is required by `&std::collections::HashMap<uuid::Uuid, std::vec::Vec<test_map_in_out::Image>>: paperclip_core::v2::schema::Apiv2Schema`
...
```

This is caused by that HashMap implements Apiv2Schema where `K: AsRef<str>` which is not the case for uuid. This change makes it more generic, requiring `K: ToString`...