### PR TITLE
Allow schema binding by dynamically generated name

### DIFF
--- a/core/src/v2/schema.rs
+++ b/core/src/v2/schema.rs
@@ -254,6 +254,8 @@ pub trait Apiv2Schema {
         let mut def = Self::raw_schema();
         if let Some(n) = Self::NAME {
             def.reference = Some(String::from("#/definitions/") + n);
+        } else if let Some(n) = def.name.as_ref() {
+            def.reference = Some(String::from("#/definitions/") + n);
         }
         if !Self::DESCRIPTION.is_empty() {
             def.description = Some(Self::DESCRIPTION.to_owned());


### PR DESCRIPTION
Currently it is not possible to generate schema name for container types, except the wrapped type `T::NAME`. But there might be different wrappers for various purposes. For instance we have wrapper for paginated results and since Rust does not support concatenation of const str I am not able to assign NAME to custom Apiv2Schema impl:
```
    impl<T: Apiv2Schema> Apiv2Schema for Paginated<T> {
        const NAME: Option<&'static str> = None;

        fn raw_schema() -> DefaultSchemaRaw {
            let mut schema = DefaultSchemaRaw::default();
            schema.name = Some(format!("Paginated{}", T::NAME.unwrap_or("Unknown")));
            schema.description = Some(format!("Paginated results.\n<br/>Item description: {}", T::DESCRIPTION));
            {
                let s = Vec::<T>::raw_schema();
                schema.properties.insert("data".into(), s.into());
            }
            {
                let mut s = Paging::raw_schema();
                s.description = Some("Paging information".to_string());
                schema.properties.insert("paging".into(), s.into());
            }
            schema
        }
    }
```

with this change generated schema for Payload wrapper will be `Paginated<TypeName>`