### PR TITLE
api_v2_operation macro adds support for multi word tags

### DIFF
--- a/book/actix-plugin.md
+++ b/book/actix-plugin.md
@@ -199,7 +199,7 @@ This can be overridden by explicitly specifying `summary` and `description` in t
   operation_id = "my_handler",
   consumes = "application/yaml, application/json",
   produces = "application/yaml, application/json",
-  tags(Cats, Dogs),
+  tags(Cats, Dogs, "Api reference"),
 )]
 async fn my_handler() -> Json<Foo> { /* */ }
 ```
@@ -316,8 +316,8 @@ spec.tags = vec![
         external_docs: None,
     },
     Tag {
-        name: "Cars".to_string(),
-        description: Some("Images of nice cars".to_string()),
+        name: "Api reference".to_string(),
+        description: Some("List of all api endpoints".to_string()),
         external_docs: None,
     },
 ];

--- a/macros/src/actix.rs
+++ b/macros/src/actix.rs
@@ -295,6 +295,8 @@ fn parse_operation_attrs(attrs: TokenStream) -> (Vec<Ident>, Vec<proc_macro2::To
                         for meta in nested.pairs().map(|pair| pair.into_value()) {
                             if let NestedMeta::Meta(Meta::Path(Path { segments, .. })) = meta {
                                 tags.push(segments[0].ident.to_string());
+                            } else if let NestedMeta::Lit(Lit::Str(lit)) = meta {
+                                tags.push(lit.value());
                             } else {
                                 emit_error!(
                                     meta.span(),

--- a/tests/test_app.rs
+++ b/tests/test_app.rs
@@ -1304,6 +1304,12 @@ fn test_tags() {
         ready(web::Json(Vec::new()))
     }
 
+    #[api_v2_operation(tags(Cats, "Nice cars"))]
+    fn some_cats_cars_images() -> impl Future<Output = web::Json<Vec<Image>>> {
+        ready(web::Json(Vec::new()))
+    }
+
+
     run_and_check_app(
         || {
             let mut spec = DefaultApiRaw::default();
@@ -1319,7 +1325,7 @@ fn test_tags() {
                     external_docs: None,
                 },
                 Tag {
-                    name: "Cars".to_string(),
+                    name: "Nice cars".to_string(),
                     description: Some("Images of nice cars".to_string()),
                     external_docs: None,
                 },
@@ -1334,6 +1340,7 @@ fn test_tags() {
                 .wrap_api_with_spec(spec)
                 .with_json_spec_at("/api/spec")
                 .service(web::resource("/images/pets").route(web::get().to(some_pets_images)))
+                .service(web::resource("/images/cats/cars").route(web::get().to(some_cats_cars_images)))
                 .build()
         },
         |addr| {
@@ -1382,6 +1389,22 @@ fn test_tags() {
                                 },
                                 "tags":[ "Cats", "Dogs" ]
                             }
+                        },
+                        "/images/cats/cars":{
+                            "get":{
+                                "responses":{
+                                "200":{
+                                    "description":"OK",
+                                    "schema":{
+                                        "items":{
+                                            "$ref":"#/definitions/Image"
+                                        },
+                                        "type":"array"
+                                    }
+                                }
+                                },
+                                "tags":[ "Cats", "Nice cars" ]
+                            }
                         }
                     },
                     "swagger":"2.0",
@@ -1396,7 +1419,7 @@ fn test_tags() {
                         },
                         {
                             "description":"Images of nice cars",
-                            "name":"Cars"
+                            "name":"Nice cars"
                         }
                     ]
                 }),


### PR DESCRIPTION
This change adds possibility to add multi word tags via str literal:
#[api_v2_operation(tags("Nice cars", Dogs))]
